### PR TITLE
Fix incorrect handling of JSON Schema for Gemini and Vertex providers

### DIFF
--- a/driver/vertex.go
+++ b/driver/vertex.go
@@ -139,6 +139,17 @@ func (v *Vertex) encode(ctx context.Context, req openai.ChatCompletionRequest) (
 		config   = &genai.GenerateContentConfig{}
 	)
 	config.CandidateCount = int32(req.N)
+
+	if rf := req.ResponseFormat; rf != nil {
+		if rf.JSONSchema == nil {
+			return nil, fmt.Errorf("json schema not provided")
+		}
+		if err := json.Unmarshal(rf.JSONSchema, &config.ResponseSchema); err != nil {
+			return nil, fmt.Errorf("cannot unmarshal json schema: %w", err)
+		}
+		config.ResponseMIMEType = "application/json"
+	}
+
 	for _, msg := range req.Messages {
 		role := ""
 		switch msg.Role {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/sashabaranov/go-openai => ./go-openai
 
 require (
 	cloud.google.com/go/aiplatform v1.74.0
+	cloud.google.com/go/auth v0.16.0
 	cloud.google.com/go/bigquery v1.66.2
 	cloud.google.com/go/storage v1.50.0
 	filippo.io/xaes256gcm v0.1.0
@@ -34,7 +35,6 @@ require (
 	cel.dev/expr v0.19.2 // indirect
 	cloud.google.com/go v0.120.0 // indirect
 	cloud.google.com/go/ai v0.10.1 // indirect
-	cloud.google.com/go/auth v0.16.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	cloud.google.com/go/iam v1.4.0 // indirect


### PR DESCRIPTION
The `openai` library we had inherited, did some wonky processing to OpenAI-specific JSON Schema, which wasn't compatible with Vertex and Gemini respective payloads.

This change addresses that.